### PR TITLE
Designer JD update

### DIFF
--- a/docs/open-positions/1-designer.md
+++ b/docs/open-positions/1-designer.md
@@ -2,42 +2,62 @@
 sidebar_position: 1
 ---
 
-# 🎨 Product Designer (Mid Level)
+# 🎨 Design Engineer (Remote)
 
-◯˚GitStart turns tickets into PRs for engineering teams. We're growing fast, with 13k+ PRs shipped to prod for Firefox Mobile, Cal.com, Drata, Supabase, StoryBook, Union Bank, and more.
+No agencies. No recruiters. We are looking for a full-time team member.
+
+## About GitStart
+
+◯˚GitStart turns tickets into PRs for engineering teams, who assign tickets and get back ready to merge PRs. We've shipped 13k+ PRs shipped for Firefox Mobile, Cal.com, Hash.AI, Drata, Supabase, StoryBook, and we're just getting started - backed by some of the best investors and engineering leaders.
 
 ## What You'll Do
+
+You'll be the go-to person for all things product design at GitStart.
+
+You'll work on a wide range of projects, from improving user journeys, designing new features to improving our design system. You'll be working closely with our product and engineering teams to create intuitive experiences for our developers and clients.
+
+Your responsibilities will include:
+
+- Gather requirements, plan and ideate new features by collaborating with teams across GitStart.
 - Craft and maintain precise specs and designs for UI that users love.
-- Give our design system a makeover and expansion that aligns perfectly with our brand vibe.
-- Collaborate with our product, engineering (wizards), and teams across GitStart, creating a sweet spot where coding meets design and brand identity.
+- Extend and improve our design system so it's aligned with our brand.
+
+YOu'll work in the sweet spot where coding meets design and brand identity.
 
 ## Who We're Looking For
-- Someone who's comfortable deep diving into to the software development lifecycle and gets excited about projects like developing a code review tool or dreaming up a new CLI or IDE.
-- Solid async communication skills, keeping everyone in the loop across platforms and formats.
-- A design storyteller, able to unpack your design choices to anyone from product managers to engineers and even folks who aren't tech-savvy.
-- Knows just when to pull in stakeholders during the design journey.
-- Balances idealistic designs with the real-world hustle of startup life, using expert judgment to navigate through.
-- A thinker who sees the big picture and how all the dots connect.
-- Ready to dive into UX research, lead user studies, or hop on research projects, always keen to integrate feedback into making designs even better.
-- Proud of your strong work ethic, happy to fly solo or team up for some serious code pairing or brainstorming sessions.
-- Gets branding and how to evolve brand directions into killer user experiences.
-- Deeply passionate about design, products, and making users go "wow!", always tinkering with software just because you love it.
+
+ We're a deeply technical company where pretty much everyone on the team has a technical background, and we're looking for someone who can match our pace and passion for software.
+
+- You have a strong technical background and are comfortable working with engineers. 
+- You have frontend programming skills and can code some of your designs.
+- You're excited about projects like developing a code review tool or dreaming up a new CLI or IDE.
+- You understand and care about browser performance, accessibility, and usability.
+- You have great async, verbal and written communication skills. You're comfortable working with a remote team and can communicate clearly and effectively across many channels.
+- You have a keen eye for detail and strong sense of ownership.
+- You can balance idealistic designs with the real-world hustle of startup life, using expert judgment to decide when to push for perfection and when to ship.
+- You're ready to do talk to users and integrate feedback into making designs even better.
+- You're happy to fly solo or team up for some serious code pairing or brainstorming sessions.
+- You get branding and how to turn an existing brand directions into amazing user experiences.
+- You're passionate about design and products, always tinkering with new apps or software just because you love it.
 
 ## Tech Toolkit
-- Must be a Figma pro (InDesign and Illustrator also work). Also, familair with Linear, GitHub, and Slack is key.
+
+You must be a Figma pro. Also, familair with Linear, GitHub, and Slack is key.
 
 ## Would Be Awesome
-- If you've ever kicked off your own project, you're our kind of people! We thrive on creativity and entrepreneurial energy, and your experience would resonate here. Plus, you can showcase your project in a Show & Tell!
+
+If you've ever kicked off your own project, you're our kind of people! We thrive on creativity and entrepreneurial energy, and your experience would resonate here. Plus, you can showcase your project in a Show & Tell!
 
 ## Work on Hard Problems
 
-[GitStart.com](http://gitstart.com/) automatically manages AI models and developers across the globe. Engineering teams assign tickets and get back ready to merge PRs. This requires rebuilding the entire engineering stack end-to-end, with pieces like:
+We're currently building the future of software development, blending people and AI to deliver production-ready code for engineering teams.
 
-- AI-first SDLC - split the software development life-cycle in steps where specialized AI models can generate code and loop in humans to make sure errors don’t propagate.
-- Ticket writing LLM - load context from the codebase and past tickets to write engineering ready tickets
-- GitSlice - securely share subsets of a codebase
+We're rebuilding the entire engineering stack end-to-end, focused on people and AI agents as first-class citizens. We're splitting the software development life-cycle into steps where specialized AI models can generate code and loop in humans to make sure errors don’t propagate, and we're building a platform that can scale to thousands of engineers and millions of tickets.
 
-## **Backed By the world’s best**
+We're here for the long haul, and we're looking for someone ready to join us on this journey.
+
+## Backed By the world’s best
+
 We are supported by the best investors in our field, Neo, YC, Bonfire VC, and the world’s best engineering leaders:
 
 - Microsoft CTO Kevin Scott
@@ -55,8 +75,9 @@ We are supported by the best investors in our field, Neo, YC, Bonfire VC, and th
 - Former Facebook CTO Mike Schroepfer
 - And more
 
-## **Join An Amazing team**
-Team includes:
+## Join An Amazing team
+
+Our team includes:
 
 - 🔥 >50% former founders, many of mission driven organizations like mPharma (Africa’s best health tech startup, 1k people $100m raised) and CodePhenix (Europe’s largest coding bootcamp for inmates)
 - 🧑‍🔬  Patents holders
@@ -67,15 +88,8 @@ Team includes:
 Also, the number one thing newcomers notice is that people are truly kind 😇. More on this when we meet!
 
 ## Perks and Benefits
-Non-standard stuff
 
-⚖️  **10 years options exercise windows** — most startups employees never exercise their hard-earned equity options because the standard clause forces them to buy it within 3 months of departure. We care so much about equity that on top of giving offers way above market, we switched to a new legal documents software solely because the old one didn’t support changing the default “3 months” to “10 years”.
-- **🛂 Visa Sponsorship:** Dream of living somewhere new? We'll help sponsor your application and help with the visa.
-- **👋 "We Got Your Back" Budget:** Life's little necessities shouldn't be a hassle. Need daycare, new glasses, or a taxi ride? Consider it covered.
-- **🌱 Growing You Budget:** Your personal and professional growth is our priority. Are you continuing your studies, studying something new or want to learn a new skill. We will help!
-- 🌎  **We are a fully remote company** — We hire the best people in the world without restriction. Work wherever and in whichever timezone you want, and travel around the world to meet the team during quarterly onsites.
-
-Standard stuff
+### Standard stuff
 
 - 📈 Equity for everyone who’s full-time
 - 🌏 Onsites
@@ -84,11 +98,20 @@ Standard stuff
 - 🍽. Meals with fellow GitStarters
 - 📞 Something missing? Tell us
 
+### Non-standard stuff
+
+-  **10 years options exercise windows** — most startups employees never exercise their hard-earned equity options because the standard clause forces them to buy it within 3 months of departure. We care so much about equity that on top of giving offers way above market, we switched to a new legal documents software solely because the old one didn’t support changing the default “3 months” to “10 years”.
+
+- **🛂 Visa Sponsorship:** Dream of living somewhere new? We'll help sponsor your application and help with the visa.
+- **👋 "We Got Your Back" Budget:** Life's little necessities shouldn't be a hassle. Need daycare, new glasses, or a taxi ride? Consider it covered.
+- **🌱 Growing You Budget:** Your personal and professional growth is our priority. Are you continuing your studies, studying something new or want to learn a new skill. We will help!
+- 🌎  **We are a fully remote company** — We hire the best people in the world without restriction. Work wherever and in whichever timezone you want, and travel around the world to meet the team during quarterly onsites.
+
 Finally, we offer competitive compensation and meaningful equity along with a chance to make a significant contribution to changing the lives of millions of engineers across the world.
 
-## **Hackweek Based recruiting**
+## The recruitment process: Hackweek-based recruiting
 
-We are weird about hiring. We’re skeptical of resumes and we don’t trust interviews (we’re happy to talk though!). Since nothing beats working together, we love inviting people for a hackweek (or hackweekend) - come hack on a problem with us and see if you like it!
+We are weird about hiring. We’re skeptical of resumes and we don’t trust interviews (we’re happy to talk though!). Since nothing beats working together, we love inviting strong candidates for a hackweek (or hackweekend, if you can't commit that much) - come hack on a problem with us and see if you like it!
 
 It’s compensated, of course. And fast: we typically extend offers within 3 working days, starting from the end of the hackweek.
 
@@ -99,7 +122,8 @@ Not sure whether this is for you? Read this candidate's feedback!
 
 ## How to apply
 
-We'd love to meet you! If you’re interested, [head here](https://app.dover.io/apply/GitStart/383e18e8-5e03-406e-a606-592cb22a36bd)!
+We repeat: no agencies. No recruiters. We are looking for a full-time team member.
 
+We'd love to meet you! If you’re interested, [head here](https://app.dover.io/apply/GitStart/383e18e8-5e03-406e-a606-592cb22a36bd)!
 
 If you want to read more about the team first, you'll find more at [Humans of GitStart](https://humansof.gitstart.com).

--- a/docs/open-positions/1-designer.md
+++ b/docs/open-positions/1-designer.md
@@ -26,9 +26,11 @@ YOu'll work in the sweet spot where coding meets design and brand identity.
 
 ## Who We're Looking For
 
- We're a deeply technical company where pretty much everyone on the team has a technical background, and we're looking for someone who can match our pace and passion for software.
+We're a deeply technical company where pretty much everyone on the team has a technical background, and we're looking for someone who can match our pace and passion for software.
 
-- You have a strong technical background and are comfortable working with engineers. 
+We care about your ability more than experience, but we expect you to have a few years of experience solo or in a similar role.
+
+- You have a strong technical background and are comfortable working with engineers.
 - You have frontend programming skills and can code some of your designs.
 - You're excited about projects like developing a code review tool or dreaming up a new CLI or IDE.
 - You understand and care about browser performance, accessibility, and usability.
@@ -118,7 +120,6 @@ It’s compensated, of course. And fast: we typically extend offers within 3 wor
 Not sure whether this is for you? Read this candidate's feedback!
 
 > See, I've been in the industry for quite a long time. And I had lots of interviews and interviewers throughout my career. Some were good, while some sucked big time; as usual. HOWEVER, and I'm not even exaggerating when I say this - interview experience with GitStart was not even ONE OF the best, but absolutely THE BEST I ever had in my 15 years career. Every person that I spoke to in the process was EXTREMELY charismatic, really eager to learn about myself and, what's more, it was absolutely obvious that they LOVED GitStart. I have NEVER EVER EVER seen anything even remotely like this. So how was the process? Amazing! I actually enjoyed it and was looking forward to more of it :D
->
 
 ## How to apply
 


### PR DESCRIPTION
Proposed changes

- Try "Design Engineer" (see [Vercel version of this JD](https://vercel.com/careers/design-engineer-uk-us-5056771004))
- Add "remote" to title to make it clearer
- Update wording throughout, be a bit more vague about AI SDLC
- Stronger wording for tech skills requirement
- NO AGENCIES. Getting spam in my inbox.